### PR TITLE
recognize errors in pipes too

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -5,6 +5,12 @@
 - notify_if_fails now also notifies on errors in piped commands
   (eg `notify_if_fails 'pg_dumpall --break|gzip|aws s3 cp - s3://bucket/file.sql.gz'`)
 
+### Develop
+
+- Allow to build image on/for arm64 platforms
+  - requires docker >v20.10 (error `unknown flag: --builder`)
+  - first time call: `gw prepareDockerContainerBuilder` (see https://github.com/lovelysystems/lovely-gradle-plugin)
+
 ## 2020-05-27 / 0.4.0
 
 - update centos to latest 7 version

--- a/CHANGES.md
+++ b/CHANGES.md
@@ -1,10 +1,15 @@
 # Changes for docker-adminbox
 
+## Unreleased
+
+- notify_if_fails now also notifies on errors in piped commands
+  (eg `notify_if_fails 'pg_dumpall --break|gzip|aws s3 cp - s3://bucket/file.sql.gz'`)
+
 ## 2020-05-27 / 0.4.0
 
 - update centos to latest 7 version
 - udpate postgres to version 14
-- use python3 to install awscli as the 
+- use python3 to install awscli as the
   standard package does not work anymore
 - update gradle
 

--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -1,5 +1,5 @@
 plugins {
-    id("com.lovelysystems.gradle") version ("1.7.0")
+    id("com.lovelysystems.gradle") version ("1.9.1")
 }
 
 lovely {

--- a/docker/notify_if_fails
+++ b/docker/notify_if_fails
@@ -8,7 +8,12 @@ then
   message="command '""$cmd""' failed"
 fi
 
-if ! bash -c "$cmd"
+# in case cmd uses pipes, capture any error within the pipe using pipefail
+# see https://stackoverflow.com/a/35465242
+bash -o pipefail -c "$cmd"
+
+# check for error (exit code != 0) and send slack notification
+if ! [ $? -eq 0 ]
 then
   slack chat send --channel "#sysadmin" --text "$message"
 fi


### PR DESCRIPTION
piped commands can lead to exit code 0 even though one or mulitple
commands within the pipe failed

since we use pipes in backup scripts (eg dump|zip|upload) we did not get
notifications on errors in the dump script (see example below)

example:

```
    :~ # pg_dumpall --foo
    pg_dumpall: unrecognized option '--foo'
    :~ # echo $?
    1
    :~ # pg_dumpall --foo|gzip
    pg_dumpall: unrecognized option '--foo'
    :~ # echo $?
    1
    :~ # pg_dumpall --foo|gzip|aws s3 cp - s3://bucket/foo.txt
    pg_dumpall: unrecognized option '--foo'
    :~ # echo $?
    0
```